### PR TITLE
Compatibility with latest symfony

### DIFF
--- a/FragmentRenderer/SSIRenderer.php
+++ b/FragmentRenderer/SSIRenderer.php
@@ -50,7 +50,7 @@ class SSIRenderer extends RoutableFragmentRenderer
             $uri = $this->generateFragmentUri($uri, $request);
         }
 
-        $uri = $this->signer->sign($uri);
+        $uri = $this->signer->sign($request->getSchemeAndHttpHost().$uri);
 
         if (!\strncmp($uri, $request->getSchemeAndHttpHost(), \strlen($request->getSchemeAndHttpHost()))) {
             $uri = \substr($uri, \strlen($request->getSchemeAndHttpHost()));

--- a/FragmentRenderer/SSIRenderer.php
+++ b/FragmentRenderer/SSIRenderer.php
@@ -50,7 +50,7 @@ class SSIRenderer extends RoutableFragmentRenderer
             $uri = $this->generateFragmentUri($uri, $request);
         }
 
-        $uri = $this->signer->sign($request->getSchemeAndHttpHost().$uri);
+        $uri = $this->signer->sign(((substr($uri,0,1) == "/")?$request->getSchemeAndHttpHost():"").$uri);
 
         if (!\strncmp($uri, $request->getSchemeAndHttpHost(), \strlen($request->getSchemeAndHttpHost()))) {
             $uri = \substr($uri, \strlen($request->getSchemeAndHttpHost()));


### PR DESCRIPTION
@KingCrunch  Right now your bundle does not work with symfony 2.8.2

If web server is configured to handle SSI requests - it generate Forbidden on all request.
After digging into this bug I noticed, that problem is in this line
https://github.com/symfony/http-kernel/blob/master/EventListener/FragmentListener.php#L83

After debugging I noticed, that your bundle sign **uri**, like
```
/_fragment?_path=pathhere
```
and symfony sign whole **url**
```
http://yourdomain.com/_fragment?_path=path&_hash=hash
```
This code was added with this commit
https://github.com/symfony/http-kernel/commit/eca461d0cdf357c3ffe9b06e49fae4a0f3b45969

after I have fixed your sign code - everything start working ok.

---

@saimaz @martiis
Before fixing bug myself I have checked forks for ready solution and located very dangerous code in your fork
https://github.com/ongr-archive/SSIBundle/commit/f665ad7daa90e7a739714abc045564f02e678ecd
![image](https://cloud.githubusercontent.com/assets/981783/12842004/89213b5a-cbf8-11e5-89e4-ccc747f0efd1.png)
not sure, if it works, but disabling security is very bad idea.

right now KingCrunch/SSIBundle should be compatible with latest symfony and I dont see any changes except compatibility in your fork - so you really should use this one instead.
